### PR TITLE
correction d'un doublon dans la liste des dépenses

### DIFF
--- a/src/data/18.json
+++ b/src/data/18.json
@@ -98,11 +98,6 @@
       "ref": 42
     },
     {
-      "amount": 16,
-      "label": "Revalorisation des salaires de la fonction publique",
-      "ref": 41
-    },
-    {
       "amount": 2,
       "label": "Mission Action extérieure de l’État",
       "ref": 42


### PR DESCRIPTION
l'élément suivant était en double : 
{
      "amount": 16,
      "label": "Revalorisation des salaires de la fonction publique",
      "ref": 41
    },